### PR TITLE
feat: docker templates with docker daemons

### DIFF
--- a/docker-in-docker/docker-network-mode-host/README.md
+++ b/docker-in-docker/docker-network-mode-host/README.md
@@ -18,38 +18,35 @@ tags: [cloud, kubernetes]
 
 ### Docker resource relevant snippet
 
+> By removing a docker network, setting `network_mode = "host"` and setting the
+> `DOCKER_HOST=localhost:2375`, running processes on any inner containers are
+> accessible from `localhost` which enables port forwarding. The trade-off is
+> network namespacing is disabled so a potential security risk.
+> 
 ```sh
-resource "docker_network" "private_network" {
-  name = "network-${data.coder_workspace.me.id}"
-}
-
 resource "docker_container" "dind" {
   image      = "docker:dind"
   privileged = true
+  network_mode = "host"
   name       = "dind-${data.coder_workspace.me.id}"
   entrypoint = ["dockerd", "-H", "tcp://0.0.0.0:2375"]
-  networks_advanced {
-    name = docker_network.private_network.name
-  }
 }
 
 resource "docker_container" "workspace" {
   count   = data.coder_workspace.me.start_count
   image   = "codercom/enterprise-golang:ubuntu"
   name    = "dev-${data.coder_workspace.me.id}"
-  command = ["sh", "-c", coder_agent.main.init_script]
+  command = ["sh", "-c", coder_agent.coder.init_script]
+  network_mode = "host"
   env = [
-    "CODER_AGENT_TOKEN=${coder_agent.main.token}",
-    "DOCKER_HOST=${docker_container.dind.name}:2375"
+    "CODER_AGENT_TOKEN=${coder_agent.coder.token}",
+    "DOCKER_HOST=localhost:2375"
   ]
   volumes {
     container_path = "/home/coder/"
     volume_name    = docker_volume.coder_volume.name
     read_only      = false
   }    
-  networks_advanced {
-    name = docker_network.private_network.name
-  }
 }
 ```
 

--- a/docker-in-docker/docker-network-mode-host/main.tf
+++ b/docker-in-docker/docker-network-mode-host/main.tf
@@ -1,0 +1,110 @@
+terraform {
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+    } 
+  }
+}
+
+provider "docker" {
+
+}
+
+data "coder_workspace" "me" {}
+
+variable "dotfiles_uri" {
+  description = <<-EOF
+  Dotfiles repo URI (optional)
+
+  see https://dotfiles.github.io
+  EOF
+  default = "git@github.com:sharkymark/dotfiles.git"
+}
+
+resource "coder_agent" "coder" {
+  os   = "linux"
+  arch = "amd64"
+  dir = "/home/coder"
+  startup_script = <<EOT
+#!/bin/bash
+
+# clone coder/coder repo
+mkdir -p ~/.ssh
+ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts
+git clone --progress git@github.com:coder/coder.git
+
+# use coder CLI to clone and install dotfiles
+coder dotfiles -y ${var.dotfiles_uri}
+
+# install and start code-server
+curl -fsSL https://code-server.dev/install.sh | sh
+code-server --auth none --port 13337 &
+
+  EOT  
+}
+
+# code-server
+resource "coder_app" "code-server" {
+  agent_id      = coder_agent.coder.id
+  slug          = "code-server"  
+  display_name  = "VS Code"
+  icon          = "/icon/code.svg"
+  url           = "http://localhost:13337?folder=/home/coder"
+  subdomain = false
+  share     = "owner"
+
+  healthcheck {
+    url       = "http://localhost:13337/healthz"
+    interval  = 3
+    threshold = 10
+  }  
+}
+
+resource "docker_container" "dind" {
+  image      = "docker:dind"
+  privileged = true
+  network_mode = "host"
+  name       = "dind-${data.coder_workspace.me.id}"
+  entrypoint = ["dockerd", "-H", "tcp://0.0.0.0:2375"]
+}
+
+resource "docker_container" "workspace" {
+  count   = data.coder_workspace.me.start_count
+  image   = "codercom/enterprise-golang:ubuntu"
+  name    = "dev-${data.coder_workspace.me.id}"
+  command = ["sh", "-c", coder_agent.coder.init_script]
+  network_mode = "host"
+  env = [
+    "CODER_AGENT_TOKEN=${coder_agent.coder.token}",
+    "DOCKER_HOST=localhost:2375"
+  ]
+  volumes {
+    container_path = "/home/coder/"
+    volume_name    = docker_volume.coder_volume.name
+    read_only      = false
+  }    
+}
+
+resource "docker_volume" "coder_volume" {
+  name = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}"
+}
+
+resource "coder_metadata" "workspace_info" {
+  count       = data.coder_workspace.me.start_count
+  resource_id = docker_container.workspace[0].id
+  item {
+    key   = "Docker host name"
+    value = "localhost:2375"
+  }       
+  item {
+    key   = "image"
+    value = "docker.io/codercom/enterprise-golang:ubuntu"
+  }
+  item {
+    key   = "repo cloned"
+    value = "docker.io/coder/coder.git"
+  }     
+}

--- a/docker-in-docker/docker-with-docker-network/README.md
+++ b/docker-in-docker/docker-with-docker-network/README.md
@@ -1,0 +1,66 @@
+---
+name: Develop in a Docker container on a Docker host and be able to use `docker build` and `docker run` and `docker compose`
+description: The goal is to enable a Docker host within a a Docker container
+tags: [cloud, kubernetes]
+---
+
+# Docker host template for a workspace in a Docker container
+
+### Apps included
+1. A web-based terminal
+1. code-server IDE (VS Code-in-a-browser)
+
+### Additional bash scripting
+1. Start Docker daemon using a privileged Docker container
+1. Prompt user and clone/install a dotfiles repository (for personalization settings)
+1. Clone coder/coder repo
+1. Download, install and start code-server (VS Code-in-a-browser)
+
+### Docker resource relevant snippet
+
+> We create a docker_network and reference it in both containers (the one
+> running a Docker daemon and the workspace container). Note the docker daemon
+> container is privileged.
+
+> You can `wget` or `curl` a process in inner containers by using the docker
+> daemon name which is `docker_container.dind.name`:<the port>
+
+```sh
+resource "docker_network" "private_network" {
+  name = "network-${data.coder_workspace.me.id}"
+}
+
+resource "docker_container" "dind" {
+  image      = "docker:dind"
+  privileged = true
+  network_mode = "host"
+  name       = "dind-${data.coder_workspace.me.id}"
+  entrypoint = ["dockerd", "-H", "tcp://0.0.0.0:2375"]
+  networks_advanced {
+    name = docker_network.private_network.name
+  }
+}
+
+resource "docker_container" "workspace" {
+  count   = data.coder_workspace.me.start_count
+  image   = "codercom/enterprise-golang:ubuntu"
+  name    = "dev-${data.coder_workspace.me.id}"
+  command = ["sh", "-c", coder_agent.coder.init_script]
+  env = [
+    "CODER_AGENT_TOKEN=${coder_agent.coder.token}",
+    "DOCKER_HOST=${docker_container.dind.name}:2375"
+  ]
+  volumes {
+    container_path = "/home/coder/"
+    volume_name    = docker_volume.coder_volume.name
+    read_only      = false
+  }    
+  networks_advanced {
+    name = docker_network.private_network.name
+  }
+}
+```
+
+### Resources
+
+[Coder Docker in Docker docs](https://coder.com/docs/coder-oss/latest/templates/docker-in-docker)

--- a/docker-in-docker/docker-with-docker-network/main.tf
+++ b/docker-in-docker/docker-with-docker-network/main.tf
@@ -5,7 +5,6 @@ terraform {
     }
     docker = {
       source  = "kreuzwerker/docker"
-      version = "~> 2.22.0"
     } 
   }
 }
@@ -104,6 +103,14 @@ resource "docker_volume" "coder_volume" {
 resource "coder_metadata" "workspace_info" {
   count       = data.coder_workspace.me.start_count
   resource_id = docker_container.workspace[0].id
+  item {
+    key   = "Docker host name"
+    value = docker_container.dind.name
+  }     
+  item {
+    key   = "Docker network name"
+    value = docker_network.private_network.name
+  }   
   item {
     key   = "image"
     value = "docker.io/codercom/enterprise-golang:ubuntu"


### PR DESCRIPTION
created a new template that is a docker workspace and creates a docker container starting a docker daemon but with `network_mode="host"` so port forwarding can be done. It's less secure since namespace isolation is removed with everyone on the workspace host.